### PR TITLE
docs(package packer): Change heading to Package Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Packer
+# Package Packer
 
 This generates an apt package for Hashicorp's [packer](https://www.packer.io). It does not configure it.
 


### PR DESCRIPTION
### What is the problem / feature?
`Package Packer` is a much funnier heading than `Packer` and is the actual name of the repository.

### How did it get fixed / implemented ?
At first I tried to make a Beavis and Butthead meme that made a joke about having a pull request for your package packer, but Github did not like the markdown image link.  So, alas I had to settle for simply changing the heading.

### How can someone test / see it ?
Go to the Package Packer Repo.  Look for the Package Packer.  Bam!  Package Packed!

Call me sometime.  I'd love to catch up.  
